### PR TITLE
Updated version of node for github actions

### DIFF
--- a/.github/workflows/cucumber.yml
+++ b/.github/workflows/cucumber.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
 
       - name: Environmental Variables

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
 
       - name: Environmental Variables


### PR DESCRIPTION
Version node installed for github actions was not compatible with updated packages, moving version from 16 to 18.